### PR TITLE
fix 侧边栏显示不全

### DIFF
--- a/src/layout/components/side_bar/Index.vue
+++ b/src/layout/components/side_bar/Index.vue
@@ -104,7 +104,8 @@ export default defineComponent({
 .sidebar-container {
   // reset element-ui css
   .horizontal-collapse-transition {
-    transition: 0s width ease-in-out, 0s padding-left ease-in-out, 0s padding-right ease-in-out;
+    transition: 0s width ease-in-out, 0s padding-left ease-in-out,
+      0s padding-right ease-in-out;
   }
 
   .scrollbar-wrapper {
@@ -112,7 +113,7 @@ export default defineComponent({
   }
 
   .el-scrollbar__view {
-    height: 100%
+    height: 100%;
   }
 
   .el-scrollbar__bar {
@@ -129,12 +130,12 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .el-scrollbar {
-  height: 100%
+  height: 100%;
 }
 
 .has-logo {
   .el-scrollbar {
-    height: calc(100% - 50px);
+    height: calc(100vh - 100px);
   }
 }
 
@@ -143,5 +144,4 @@ export default defineComponent({
   height: 100%;
   width: 100% !important;
 }
-
 </style>


### PR DESCRIPTION
### SideBar 组件左侧边栏显示不完整的修复
> sidebar 左侧边栏， zip显示不全， 同时全屏展示时， zip没有显示出来， 修改了el-scrollbar的样式， 使其显示正常