### PR TITLE
fix(401页面)：修复点击“点我看图”按钮弹框页面未展示问题

### DIFF
--- a/src/views/error-page/401.vue
+++ b/src/views/error-page/401.vue
@@ -54,7 +54,7 @@
       </el-col>
     </el-row>
     <el-dialog
-      v-model:visible="dialogVisible"
+      v-model="dialogVisible"
       title="随便看"
     >
       <img


### PR DESCRIPTION
生产环境【 错误页面 -> 401 】页面中的 【点我看图】按钮，点击并没有弹框，因为element-plus 针对el-dialog组件不支持 :visible了，已经修复该问题。